### PR TITLE
UPDATE: devise reset passwod mail content, reset_password_within

### DIFF
--- a/app/mailers/devise_reset_password.html.erb
+++ b/app/mailers/devise_reset_password.html.erb
@@ -1,8 +1,0 @@
-<p>Hello <%= @resource.email %>!</p>
-
-<p>Someone has requested a link to change your password. You can do this through the link below.</p>
-
-<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
-
-<p>If you didn't request this, please ignore this email.</p>
-<p>Your password won't change until you access the link above and create a new one.</p>

--- a/app/views/users/mailer/reset_password_instructions.html.erb
+++ b/app/views/users/mailer/reset_password_instructions.html.erb
@@ -1,8 +1,18 @@
-<p><%= t('.greeting', recipient: @resource.email) %></p>
+<p><%= t('.greeting', recipient: @resource.account_name) %></p>
+</br>
 
 <p><%= t('.instruction') %></p>
+<p><%= t('.instruction_2') %></p>
+</br>
 
 <p><%= link_to t('.action'), edit_password_url(@resource, reset_password_token: @token) %></p>
+</br>
 
-<p><%= t('.instruction_2') %></p>
 <p><%= t('.instruction_3') %></p>
+</br>
+
+<p><%= t('.instruction_4') %></p>
+<p><%= t('.instruction_5') %></p>
+</br>
+
+<p><%= t('.period') %></p>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -227,7 +227,8 @@ Devise.setup do |config|
   # Time interval you can reset your password with a reset password key.
   # Don't put a too small interval or your users won't have the time to
   # change their passwords.
-  config.reset_password_within = 6.hours
+  # config.reset_password_within = 6.hours
+  config.reset_password_within = 30.minutes
 
   # When set to false, does not sign a user in automatically after their password is
   # reset. Defaults to true, so a user is signed in automatically after a reset.

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -56,16 +56,19 @@ ja:
         message_unconfirmed: メールアドレスが（%{email}）変更されたため、メールを送信しています。
         subject: メール変更完了
       password_change:
-        greeting: "%{recipient}様"
+        greeting: "%{recipient} 様"
         message: パスワードが再設定されました。
         subject: パスワードの変更について
       reset_password_instructions:
-        action: パスワード変更
+        action: パスワードのリセットおよび変更はこちらのリンクから
         greeting: "%{recipient}様"
-        instruction: パスワード再設定の依頼を受けたため、メールを送信しています。下のリンクからパスワードの再設定ができます。
-        instruction_2: パスワード再設定の依頼をしていない場合、このメールを無視してください。
+        instruction: パスワードリセットのリクエストを受け付けました。
+        instruction_2: 新しいパスワードを設定するには、以下のリンクをクリックしてください：
         instruction_3: パスワードの再設定は、上のリンクから新しいパスワードを登録するまで完了しません。
-        subject: パスワードの再設定について
+        instruction_4: もしパスワード再設定の依頼をしていない場合、このメールを無視してください。
+        instruction_5: ご不明な点がございましたら、フッターのお問い合わせフォームよりお問い合わせください。
+        period: アイデア収集場
+        subject: パスワードの再設定のご案内 【アイデア収集場】
       unlock_instructions:
         action: アカウントのロック解除
         greeting: "%{recipient}様"
@@ -82,7 +85,7 @@ ja:
         confirm_new_password: 確認用新しいパスワード
         new_password: 新しいパスワード
       new:
-        forgot_your_password: パスワードを忘れましたか？
+        forgot_your_password: パスワードの再設定
         send_me_reset_password_instructions: パスワード再設定のメールを送信
       no_token: このページにはアクセスできません。パスワード再設定メールのリンクからアクセスされた場合には、URL をご確認ください。
       send_instructions: パスワードの再設定について数分以内にメールでご連絡いたします。


### PR DESCRIPTION
# 概要
* パスワードリセットのメール本文の見直し
* パスワードリセットのメールリンクの有効期限を30分に変更
